### PR TITLE
FreeRTOS function names have changed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(COMPONENT_ADD_INCLUDEDIRS "src")
-set(COMPONENT_SRCDIRS "src")
-register_component()
 
+idf_component_register(SRCS "src/BNO055ESP32.cpp"
+                    INCLUDE_DIRS "src/"
+                    REQUIRES driver)
+
+target_compile_options(${COMPONENT_LIB} PUBLIC -std=gnu++11)

--- a/src/BNO055ESP32.cpp
+++ b/src/BNO055ESP32.cpp
@@ -219,7 +219,7 @@ void BNO055::uart_readLen(bno055_reg_t reg, uint8_t *buffer, uint8_t len, uint32
         // else expect ACK/response
 
         // Read data from the UART
-        int rxBytes = uart_read_bytes(_uartPort, data, (len + 2), timeoutMS / portTICK_RATE_MS);
+        int rxBytes = uart_read_bytes(_uartPort, data, (len + 2), timeoutMS / portTICK_PERIOD_MS);
         if (rxBytes > 0) {
 #ifndef BNO055_DEBUG_OFF
             ESP_LOGD(BNO055_LOG_TAG, "(RL) Read %d bytes", rxBytes);
@@ -289,7 +289,7 @@ void BNO055::uart_writeLen(bno055_reg_t reg, uint8_t *data2write, uint8_t len, u
         }
         // else expect ACK/response
 
-        int rxBytes = uart_read_bytes(_uartPort, data, 2, timeoutMS / portTICK_RATE_MS);
+        int rxBytes = uart_read_bytes(_uartPort, data, 2, timeoutMS / portTICK_PERIOD_MS);
         if (rxBytes > 0) {
 #ifndef BNO055_DEBUG_OFF
             ESP_LOGD(BNO055_LOG_TAG, "(WL) Read %d bytes", rxBytes);  // DEBUG
@@ -483,7 +483,7 @@ void BNO055::reset() {
 #ifndef BNO055_DEBUG_OFF
         ESP_LOGD(BNO055_LOG_TAG, "RST -> using hardware pin");  // DEBUG
 #endif
-        gpio_pad_select_gpio(_rstPin);
+        esp_rom_gpio_pad_select_gpio(_rstPin);
         gpio_set_direction(_rstPin, GPIO_MODE_OUTPUT);
         gpio_set_level(_rstPin, 0);  // turn OFF
         vTaskDelay(1 / portTICK_PERIOD_MS);
@@ -924,7 +924,7 @@ void BNO055::begin() {
 #endif
 
     if (_intPin != GPIO_NUM_MAX) {
-        gpio_pad_select_gpio(_intPin);
+        esp_rom_gpio_pad_select_gpio(_intPin);
         gpio_set_direction(_intPin, GPIO_MODE_INPUT);
         gpio_set_intr_type(_intPin, GPIO_INTR_POSEDGE);
         gpio_set_pull_mode(_intPin, GPIO_PULLDOWN_ONLY);

--- a/src/BNO055ESP32.h
+++ b/src/BNO055ESP32.h
@@ -665,7 +665,7 @@ class BNO055 {
                                        .stop_bits = UART_STOP_BITS_1,
                                        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
                                        .rx_flow_ctrl_thresh = 0,
-                                       .use_ref_tick = false};
+                                       };
 
     typedef enum {
         BNO055_VECTOR_ACCELEROMETER = 0x08,  // Default: m/s²


### PR DESCRIPTION
Hello, 

This piece of code was very useful for me so thank you for your work, however, I had to update the function names, cmake list and edit some structures to get it working as FreeRTOS have updated their names. Also changed CMakeLists as `driver/i2c.h` was throwing errors which was fixed by adding `REQUIRES driver`. 